### PR TITLE
Fixed misses and bad cuts being improperly tracked

### DIFF
--- a/ComboSplitter/ComboSplitter.csproj
+++ b/ComboSplitter/ComboSplitter.csproj
@@ -103,6 +103,7 @@
     <Reference Include="HMUI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
       <Private>False</Private>
+      <Publicize>True</Publicize>
     </Reference>
     <Reference Include="IPA.Loader">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
@@ -152,6 +153,7 @@
     <EmbeddedResource Include="SettingsUI\main.bsml" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="ComboSplitter.csproj.user" />
     <None Include="Directory.Build.props" Condition="Exists('Directory.Build.props')" />
     <None Include="ComboSplitter.csproj.user" Condition="Exists('ComboSplitter.csproj.user')" />
   </ItemGroup>

--- a/ComboSplitter/Services/SpecificHandComboHoverHintController.cs
+++ b/ComboSplitter/Services/SpecificHandComboHoverHintController.cs
@@ -1,8 +1,8 @@
 ﻿using BeatSaberMarkupLanguage;
 using HMUI;
-using SiraUtil.Logging;
+using IPA.Utilities;
 using System.Text;
-using System.Windows.Forms;
+using TMPro;
 using UnityEngine;
 using Zenject;
 
@@ -82,8 +82,9 @@ namespace ComboSplitter.Services
             {
                 Transform goodCutsParent = resultsViewController.transform.Find("Container/ClearedInfo/GoodCuts");
                 GameObject goodCutsGO = goodCutsParent.gameObject;
-                transform.SetParent(goodCutsParent);
+                this.transform.SetParent(goodCutsParent);
                 resultsHoverHint = BeatSaberUI.DiContainer.InstantiateComponent<HoverHint>(goodCutsGO);
+                resultsHoverHint._hoverHintController._hoverHintPanel._text.horizontalAlignment = HorizontalAlignmentOptions.Center;
             }
             if (addedToHierarchy)
             {


### PR DESCRIPTION
Visual errors were addressed in this PR as well as other minor internal changes to address performance and boilerplate:
* Publicized HMUI to hardcode text alignment in the hover hint.
* More accurately account for bomb hits and bad cuts.
* Use more private fields and public wrappers.

Fairly small but has important changes. Should be the last little bit before release.